### PR TITLE
Update to JDK 11

### DIFF
--- a/hazelcast-jet-enterprise/Dockerfile
+++ b/hazelcast-jet-enterprise/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8u201-jre-alpine
+FROM openjdk:11.0.7-jre-slim
 
 # Versions of Hazelcast Jet and Hazelcast IMDG plugins
 ARG JET_VERSION=4.1
@@ -13,8 +13,10 @@ ARG CACHE_API_JAR="cache-api-${CACHE_API_VERSION}.jar"
 ARG HZ_AWS_API_JAR="hazelcast-aws-${HZ_AWS_VERSION}.jar"
 
 # Install bash & curl
-RUN apk add --no-cache bash curl \
- && rm -rf /var/cache/apk/*
+RUN apt-get update && apt-get -y install \
+ bash \
+ curl \
+ && apt-get clean
 
 # Set up build directory
 RUN mkdir -p ${JET_HOME}

--- a/hazelcast-jet-enterprise/Dockerfile
+++ b/hazelcast-jet-enterprise/Dockerfile
@@ -53,7 +53,8 @@ COPY log4j2.properties ${JET_HOME}/config/log4j2.properties
 
 # Runtime constants
 ENV CLASSPATH_DEFAULT "${JET_HOME}:${JET_HOME}/*:${JET_HOME}/lib:${JET_HOME}/lib/*"
-ENV JAVA_OPTS_DEFAULT "-Djava.net.preferIPv4Stack=true -Dhazelcast.logging.type=log4j2 -Dlog4j.configurationFile=file:$JET_HOME/config/log4j2.properties -Djet.home=$JET_HOME -Dhazelcast.config=$JET_HOME/config/hazelcast.yaml -Dhazelcast.client.config=$JET_HOME/config/hazelcast-client.yaml -Dhazelcast.jet.config=$JET_HOME/config/hazelcast-jet.yaml"
+ENV JAVA_OPTS_DEFAULT "--add-modules java.se --add-exports java.base/jdk.internal.ref=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.nio=ALL-UNNAMED --add-opens java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.management/sun.management=ALL-UNNAMED --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED \
+ -Djava.net.preferIPv4Stack=true -Dhazelcast.logging.type=log4j2 -Dlog4j.configurationFile=file:$JET_HOME/config/log4j2.properties -Djet.home=$JET_HOME -Dhazelcast.config=$JET_HOME/config/hazelcast.yaml -Dhazelcast.client.config=$JET_HOME/config/hazelcast-client.yaml -Dhazelcast.jet.config=$JET_HOME/config/hazelcast-jet.yaml"
 
 # Runtime environment variables
 ENV JET_HOME $JET_HOME

--- a/hazelcast-jet-oss/Dockerfile
+++ b/hazelcast-jet-oss/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8u201-jre-alpine
+FROM openjdk:11.0.7-jre-slim
 
 # Versions of Hazelcast Jet and Hazelcast IMDG plugins
 ARG JET_VERSION=4.1
@@ -11,8 +11,10 @@ ARG JET_HOME="/opt/hazelcast-jet"
 ARG JET_JAR="hazelcast-jet-${JET_VERSION}.jar"
 
 # Install bash & curl
-RUN apk add --no-cache bash curl \
- && rm -rf /var/cache/apk/*
+RUN apt-get update && apt-get -y install \
+ bash \
+ curl \
+ && apt-get clean
 
 # Set up build directory
 RUN mkdir -p ${JET_HOME}
@@ -49,7 +51,8 @@ COPY log4j2.properties ${JET_HOME}/config/log4j2.properties
 
 # Runtime constants
 ENV CLASSPATH_DEFAULT "${JET_HOME}:${JET_HOME}/*:${JET_HOME}/lib:${JET_HOME}/lib/*"
-ENV JAVA_OPTS_DEFAULT "-Djava.net.preferIPv4Stack=true -Dhazelcast.logging.type=log4j2 -Dlog4j.configurationFile=file:$JET_HOME/config/log4j2.properties -Djet.home=$JET_HOME -Dhazelcast.config=$JET_HOME/config/hazelcast.yaml -Dhazelcast.client.config=$JET_HOME/config/hazelcast-client.yaml -Dhazelcast.jet.config=$JET_HOME/config/hazelcast-jet.yaml"
+ENV JAVA_OPTS_DEFAULT "--add-modules java.se --add-exports java.base/jdk.internal.ref=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.nio=ALL-UNNAMED --add-opens java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.management/sun.management=ALL-UNNAMED --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED \
+ -Djava.net.preferIPv4Stack=true -Dhazelcast.logging.type=log4j2 -Dlog4j.configurationFile=file:$JET_HOME/config/log4j2.properties -Djet.home=$JET_HOME -Dhazelcast.config=$JET_HOME/config/hazelcast.yaml -Dhazelcast.client.config=$JET_HOME/config/hazelcast-client.yaml -Dhazelcast.jet.config=$JET_HOME/config/hazelcast-jet.yaml"
 
 # Runtime environment variables
 ENV JET_HOME $JET_HOME

--- a/openshift/hazelcast-jet-enterprise/Dockerfile
+++ b/openshift/hazelcast-jet-enterprise/Dockerfile
@@ -39,7 +39,7 @@ RUN mkdir -p ${JET_HOME} && \
       dnf update -y  && rm -rf /var/cache/dnf && \
       dnf -y update-minimal --security --sec-severity=Important --sec-severity=Critical --setopt=tsflags=nodocs && \
       ### Add your package needs to this installation line
-      dnf -y --setopt=tsflags=nodocs install java-1.8.0-openjdk-devel apr openssl &> /dev/null && \
+      dnf -y --setopt=tsflags=nodocs install java-11-openjdk-headless apr openssl &> /dev/null && \
       ### Install go-md2man to help markdown to man conversion
       dnf -y --setopt=tsflags=nodocs install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm &> /dev/null && \
       dnf -y --setopt=tsflags=nodocs install golang-github-cpuguy83-go-md2man &> /dev/null && \
@@ -77,7 +77,8 @@ COPY log4j2.properties ${JET_HOME}/config/log4j2.properties
 
 # Runtime constants
 ENV CLASSPATH_DEFAULT "${JET_HOME}:${JET_HOME}/*:${JET_HOME}/lib:${JET_HOME}/lib/*"
-ENV JAVA_OPTS_DEFAULT "-Djava.net.preferIPv4Stack=true -Dhazelcast.logging.type=log4j2 -Dlog4j.configurationFile=file:$JET_HOME/config/log4j2.properties -Djet.home=$JET_HOME -Dhazelcast.config=$JET_HOME/config/hazelcast.yaml -Dhazelcast.client.config=$JET_HOME/config/hazelcast-client.yaml -Dhazelcast.jet.config=$JET_HOME/config/hazelcast-jet.yaml"
+ENV JAVA_OPTS_DEFAULT "--add-modules java.se --add-exports java.base/jdk.internal.ref=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.nio=ALL-UNNAMED --add-opens java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.management/sun.management=ALL-UNNAMED --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED \
+ -Djava.net.preferIPv4Stack=true -Dhazelcast.logging.type=log4j2 -Dlog4j.configurationFile=file:$JET_HOME/config/log4j2.properties -Djet.home=$JET_HOME -Dhazelcast.config=$JET_HOME/config/hazelcast.yaml -Dhazelcast.client.config=$JET_HOME/config/hazelcast-client.yaml -Dhazelcast.jet.config=$JET_HOME/config/hazelcast-jet.yaml"
 
 # Runtime environment variables
 ENV JET_HOME $JET_HOME


### PR DESCRIPTION
This is a minimal set of changes to migrate to JDK 11.

Using official openjdk image, based on Debian Buster.
Leads to smaller image than using Alpine and installing openjdk-jre.
Also Alpine repository has only 11.0.5.