### PR TITLE
Remove default hazelcast.yaml from Red Hat OpenShift image

### DIFF
--- a/openshift/hazelcast-jet-enterprise/hazelcast.yaml
+++ b/openshift/hazelcast-jet-enterprise/hazelcast.yaml
@@ -1,7 +1,0 @@
-hazelcast:
-  network:
-    join:
-      multicast:
-        enabled: false
-      kubernetes:
-        enabled: true


### PR DESCRIPTION
I don't believe we need to have the default `hazelcast.yaml`, because:
1. Red Hat certified image can be used without OpenShift/Kubernetes
2. With the introduction of auto-detection, the behavior is actually the same

Related to https://github.com/hazelcast/hazelcast-openshift/pull/40