### PR TITLE
Fix latest handling

### DIFF
--- a/.github/workflows/latest_snapshot_image_push.yml
+++ b/.github/workflows/latest_snapshot_image_push.yml
@@ -1,4 +1,4 @@
-name: Build latest OS and EE image
+name: Build latest-snapshot OS and EE image
 
 on:
   workflow_dispatch:
@@ -28,11 +28,11 @@ jobs:
         run: |
           docker buildx build --push \
             --build-arg JET_VERSION=${{ github.event.inputs.JET_VERSION }} \
-            --tag hazelcast/hazelcast-jet:latest \
+            --tag hazelcast/hazelcast-jet:latest-snapshot \
             --platform=linux/arm64,linux/amd64 hazelcast-jet-oss
       - name: Build/Push EE image
         run: |
           docker buildx build --push \
             --build-arg JET_VERSION=${{ github.event.inputs.JET_VERSION }} \
-            --tag hazelcast/hazelcast-jet-enterprise:latest \
+            --tag hazelcast/hazelcast-jet-enterprise:latest-snapshot \
             --platform=linux/arm64,linux/amd64 hazelcast-jet-enterprise

--- a/.github/workflows/tag_image_push.yml
+++ b/.github/workflows/tag_image_push.yml
@@ -11,12 +11,20 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Set Release Version
-        run: echo ::set-env name=RELEASE_VERSION::${GITHUB_REF:11}
+        run: echo "RELEASE_VERSION=${GITHUB_REF:11}" >> $GITHUB_ENV
       - name: Print Release Version
         run: |
           echo ${{ env.RELEASE_VERSION }}
+
+      - name: Check if latest tag should be pushed
+        run: echo "PUSH_LATEST=$([[ $(git tag --list "v*" | sort | tail -n 1) = "${GITHUB_REF:10}" ]] && echo yes || echo no)" >> $GITHUB_ENV
+      - name: Print Push Latest
+        run: |
+          echo ${{ env.PUSH_LATEST }}
 
       - name: Set up Docker Buildx
         id: buildx
@@ -30,11 +38,26 @@ jobs:
 
       - name: Build/Push OSS image
         run: |
-          docker buildx build --push \
-            --tag hazelcast/hazelcast-jet:${{ env.RELEASE_VERSION }} \
-            --platform=linux/arm64,linux/amd64 hazelcast-jet-oss
+          if [[ "${{ env.PUSH_LATEST }}" == "yes" ]]; then
+            docker buildx build --push \
+              --tag hazelcast/hazelcast-jet:${{ env.RELEASE_VERSION }} \
+              --tag hazelcast/hazelcast-jet:latest \
+              --platform=linux/arm64,linux/amd64 hazelcast-jet-oss
+          else
+            docker buildx build --push \
+              --tag hazelcast/hazelcast-jet:${{ env.RELEASE_VERSION }} \
+              --platform=linux/arm64,linux/amd64 hazelcast-jet-oss
+          fi
+
       - name: Build/Push EE image
         run: |
-          docker buildx build --push \
-            --tag hazelcast/hazelcast-jet-enterprise:${{ env.RELEASE_VERSION }} \
-            --platform=linux/arm64,linux/amd64 hazelcast-jet-enterprise
+          if [[ "${{ env.PUSH_LATEST }}" == "yes" ]]; then
+            docker buildx build --push \
+              --tag hazelcast/hazelcast-jet-enterprise:${{ env.RELEASE_VERSION }} \
+              --tag hazelcast/hazelcast-jet-enterprise:latest \
+              --platform=linux/arm64,linux/amd64 hazelcast-jet-enterprise
+          else
+            docker buildx build --push \
+              --tag hazelcast/hazelcast-jet-enterprise:${{ env.RELEASE_VERSION }} \
+              --platform=linux/arm64,linux/amd64 hazelcast-jet-enterprise
+          fi


### PR DESCRIPTION
Push latest image when building latest tag.
We need to set `fetch-depth: 0` to get all history, including tags to find out if we are building the latest tag.
Getting all history should be fine in this repo.

Change latest to latest-snapshot in the externally started build.