### PR TITLE
Add retry to dependency download

### DIFF
--- a/hazelcast-jet-enterprise/Dockerfile
+++ b/hazelcast-jet-enterprise/Dockerfile
@@ -18,6 +18,7 @@ RUN mvn -f dependency-copy.xml \
       -Dhazelcast-eureka-version=${HZ_EUREKA_VERSION} \
       -Dhazelcast-jet-version=${JET_VERSION} \
       -Djcache-version=${CACHE_API_VERSION} \
+      -Dmaven.wagon.http.retryHandler.count=3 \
       dependency:copy-dependencies \
       dependency:unpack && \
       mv hazelcast-jet-enterprise-${JET_VERSION} hazelcast-jet-enterprise && \

--- a/hazelcast-jet-oss/Dockerfile
+++ b/hazelcast-jet-oss/Dockerfile
@@ -18,6 +18,7 @@ RUN mvn -f dependency-copy.xml \
       -Dhazelcast-eureka-version=${HZ_EUREKA_VERSION} \
       -Dhazelcast-jet-version=${JET_VERSION} \
       -Djcache-version=${CACHE_API_VERSION} \
+      -Dmaven.wagon.http.retryHandler.count=3 \
       dependency:copy-dependencies \
       dependency:unpack && \
       mv hazelcast-jet-${JET_VERSION} hazelcast-jet && \

--- a/openshift/hazelcast-jet-enterprise/Dockerfile
+++ b/openshift/hazelcast-jet-enterprise/Dockerfile
@@ -57,6 +57,7 @@ RUN cd mvnw && \
       -Dhazelcast-eureka-version=${HZ_EUREKA_VERSION} \
       -Dhazelcast-jet-version=${JET_VERSION} \
       -Djcache-version=${CACHE_API_VERSION} \
+      -Dmaven.wagon.http.retryHandler.count=3 \
       dependency:copy-dependencies \
       dependency:unpack && \
       cd .. && \


### PR DESCRIPTION
Sometimes we hit an intermittent connection issue while downloading the artifacts for the image:

```
Failed to execute goal on project dep-download: Could not resolve dependencies for project dep-download:dep-download:jar:0.0.0: Could not transfer artifact com.thoughtworks.xstream:xstream:jar:1.4.11.1 from/to central (https://repo.maven.apache.org/maven2): GET request of: com/thoughtworks/xstream/xstream/1.4.11.1/xstream-1.4.11.1.jar from central failed: Connection reset -> [Help 1]
```

The retry should handle such cases.